### PR TITLE
feature/SM-6146: add OffenceCode array to FPNCSVExportRequest

### DIFF
--- a/dist/interfaces/fpnCSVExportRequest.d.ts
+++ b/dist/interfaces/fpnCSVExportRequest.d.ts
@@ -1,9 +1,10 @@
 import { BaseCSVExportRequest } from './baseCSVExportRequest';
-import { FPNStatus } from './referenceTypes';
+import { FPNStatus, OffenceCode } from './referenceTypes';
 export interface FPNCSVExportRequest extends BaseCSVExportRequest {
     status?: FPNStatus[];
     /** start_date must be before or the same as end_date if both are provided */
     start_date?: Date;
     /** end_date must be the same as or after start_date if both are provided */
     end_date?: Date;
+    offence_code?: OffenceCode[];
 }

--- a/dist/interfaces/referenceTypes.d.ts
+++ b/dist/interfaces/referenceTypes.d.ts
@@ -123,3 +123,9 @@ export declare enum InspectionOutcome {
     works_in_progress = "works_in_progress",
     works_stopped = "works_stopped"
 }
+export declare enum OffenceCode {
+    offence_code_05 = "offence_code_05",
+    offence_code_06 = "offence_code_06",
+    offence_code_08 = "offence_code_08",
+    offence_code_09 = "offence_code_09"
+}

--- a/dist/interfaces/referenceTypes.js
+++ b/dist/interfaces/referenceTypes.js
@@ -141,3 +141,10 @@ var InspectionOutcome;
     InspectionOutcome["works_in_progress"] = "works_in_progress";
     InspectionOutcome["works_stopped"] = "works_stopped";
 })(InspectionOutcome = exports.InspectionOutcome || (exports.InspectionOutcome = {}));
+var OffenceCode;
+(function (OffenceCode) {
+    OffenceCode["offence_code_05"] = "offence_code_05";
+    OffenceCode["offence_code_06"] = "offence_code_06";
+    OffenceCode["offence_code_08"] = "offence_code_08";
+    OffenceCode["offence_code_09"] = "offence_code_09";
+})(OffenceCode = exports.OffenceCode || (exports.OffenceCode = {}));

--- a/src/interfaces/fpnCSVExportRequest.ts
+++ b/src/interfaces/fpnCSVExportRequest.ts
@@ -1,5 +1,5 @@
 import { BaseCSVExportRequest } from './baseCSVExportRequest'
-import { FPNStatus } from './referenceTypes'
+import { FPNStatus, OffenceCode } from './referenceTypes'
 
 export interface FPNCSVExportRequest extends BaseCSVExportRequest {
   status?: FPNStatus[]
@@ -7,4 +7,5 @@ export interface FPNCSVExportRequest extends BaseCSVExportRequest {
   start_date?: Date
   /** end_date must be the same as or after start_date if both are provided */
   end_date?: Date
+  offence_code?: OffenceCode[]
 }

--- a/src/interfaces/referenceTypes.ts
+++ b/src/interfaces/referenceTypes.ts
@@ -138,3 +138,10 @@ export enum InspectionOutcome {
   works_in_progress = 'works_in_progress',
   works_stopped = 'works_stopped'
 }
+
+export enum OffenceCode {
+  offence_code_05 = 'offence_code_05',
+  offence_code_06 = 'offence_code_06',
+  offence_code_08 = 'offence_code_08',
+  offence_code_09 = 'offence_code_09'
+}


### PR DESCRIPTION
## Description

add optional offence code filter param to the FPNCSVExportRequest

reporting api: https://github.com/departmentfortransport/street-manager-reporting-api/pull/331
reporting client: https://github.com/departmentfortransport/street-manager-reporting-client/pull/120

data export api: https://github.com/departmentfortransport/street-manager-data-export-api/pull/89
data export client: https://github.com/departmentfortransport/street-manager-data-export-client/pull/26

CSV Jobs: https://github.com/departmentfortransport/street-manager-csv-jobs/pull/79
CSV Worker: https://github.com/departmentfortransport/street-manager-csv-worker/pull/66

## Coding Standards

Style guide: https://github.com/departmentfortransport/street-manager/wiki/Street-Manager-Style-Guide
Coding best practices: https://github.com/departmentfortransport/street-manager/wiki/Street-Manager-Coding-Best-Practices

## Checklist

- [ ] Branch named {feature|hotfix|task}/{SM-.*}
- [ ] If your pull request depends on any other, please link them
- [ ] Changes approved by your team
- [ ] Changes approved by another team
- [ ] API definitions updated
- [ ] Commit messages are meaningful
- [ ] Add `DO NOT MERGE` if you want to postpone merge
