### PR TITLE
SM-6097: Remove getWorkDataCSV method from client

### DIFF
--- a/dist/app/client.d.ts
+++ b/dist/app/client.d.ts
@@ -40,7 +40,6 @@ export declare class StreetManagerDataExportClient {
     generatePermitsCreatedCSV(config: RequestConfig, request: PermitsCreatedCSVExportRequest): Promise<CSVExportResponse>;
     generateFPNsCreatedCSV(config: RequestConfig, request: FPNsCreatedCSVExportRequest): Promise<CSVExportResponse>;
     getCSV(config: RequestConfig, csvId: number): Promise<AxiosResponse<Stream>>;
-    getWorkDataCSV(requestConfig: RequestConfig, getDataCSVRequest: GetDataCSVRequest): Promise<AxiosResponse<Stream>>;
     getActivityDataCSV(requestConfig: RequestConfig, getDataCSVRequest: GetDataCSVRequest): Promise<AxiosResponse<Stream>>;
     private httpHandler;
     private generateRequestConfig;

--- a/dist/app/client.js
+++ b/dist/app/client.js
@@ -96,16 +96,6 @@ class StreetManagerDataExportClient {
             }
         });
     }
-    getWorkDataCSV(requestConfig, getDataCSVRequest) {
-        return __awaiter(this, void 0, void 0, function* () {
-            try {
-                return yield this.axios.get('/work-data', this.generateRequestConfig(requestConfig, getDataCSVRequest));
-            }
-            catch (err) {
-                return this.handleError(err);
-            }
-        });
-    }
     getActivityDataCSV(requestConfig, getDataCSVRequest) {
         return __awaiter(this, void 0, void 0, function* () {
             try {

--- a/src/app/client.ts
+++ b/src/app/client.ts
@@ -104,14 +104,6 @@ export class StreetManagerDataExportClient {
     }
   }
 
-  public async getWorkDataCSV(requestConfig: RequestConfig, getDataCSVRequest: GetDataCSVRequest): Promise<AxiosResponse<Stream>> {
-    try {
-      return await this.axios.get('/work-data', this.generateRequestConfig(requestConfig, getDataCSVRequest))
-    } catch (err) {
-      return this.handleError(err)
-    }
-  }
-
   public async getActivityDataCSV(requestConfig: RequestConfig, getDataCSVRequest: GetDataCSVRequest): Promise<AxiosResponse<Stream>> {
     try {
       return await this.axios.get('/activity-data', this.generateRequestConfig(requestConfig, getDataCSVRequest))


### PR DESCRIPTION
## Description

Remove getWorkDataCSV method from client

## Coding Standards

Style guide: https://github.com/departmentfortransport/street-manager/wiki/Street-Manager-Style-Guide
Coding best practices: https://github.com/departmentfortransport/street-manager/wiki/Street-Manager-Coding-Best-Practices

## Checklist

- [ ] Branch named {feature|hotfix|task}/{SM-.*}
- [ ] If your pull request depends on any other, please link them
- [ ] Changes approved by your team
- [ ] Changes approved by another team
- [ ] API definitions updated
- [ ] Commit messages are meaningful
- [ ] Add `DO NOT MERGE` if you want to postpone merge
